### PR TITLE
edit to display full location on profile

### DIFF
--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -35,7 +35,15 @@
                               </h3>
                                <p class="list-group-item-text">
                                  <span class="glyphicon glyphicon-globe" aria-hidden="true"></span>&nbsp;
-                                 <% if org.org_city %><%= org.org_city %><% else %>City not provided.<% end %>
+                                 <% if !org.org_city.blank? %>
+                                  <%= org.org_city %>
+                                 <% else %>
+                                  <% if org.org_state %>
+                                    <% org.org_state %>
+                                  <% else %>
+                                    Location not provided.
+                                  <% end %>
+                                <% end %>
                               </p>
                                <p class="list-group-item-text">
                                  <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>&nbsp;

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -27,6 +27,9 @@
           <% if @org.org_city.blank? && @org.org_state.blank? %>
             Not provided.
           <% else %>
+            <% if !@org.org_address.blank? %>
+              <%= @org.org_address+", " %>
+            <% end %>
             <%= @org.org_city+", "+@org.org_state %>
           <% end %>
         </li>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -35,7 +35,15 @@
                            </h3>
                            <p class="list-group-item-text">
                               <span class="glyphicon glyphicon-globe" aria-hidden="true"></span>&nbsp;
-                              <% if user.city %><%= user.city %><% else %>City not provided.<% end %>
+                              <% if !user.city.blank? %>
+                               <%= user.city %>
+                              <% else %>
+                               <% if user.state %>
+                                 <% user.state %>
+                               <% else %>
+                                 Location not provided.
+                               <% end %>
+                             <% end %>
                            </p>
                            <p class="list-group-item-text">
                               <span class="glyphicon glyphicon-envelope" aria-hidden="true"></span>&nbsp;


### PR DESCRIPTION
* org profile now has their full address (incl. street address)
* if org has city, then display city in the organizations list. If not, see if it has a state and display state. If not, say ``location not provided``
* same thing for users